### PR TITLE
add weakdeps - extensions

### DIFF
--- a/src/JuliaProjectFormatter.jl
+++ b/src/JuliaProjectFormatter.jl
@@ -10,7 +10,7 @@ using ..JuliaProjectFormatter: JuliaProjectFormatter
 
 using TOML
 
-const _project_key_order = ["name", "uuid", "keywords", "license", "desc", "deps", "compat"]
+const _project_key_order = ["name", "uuid", "keywords", "license", "desc", "deps", "compat", "weakdeps", "extensions"]
 project_key_order(key::String) =
     something(findfirst(x -> x == key, _project_key_order), length(_project_key_order) + 1)
 


### PR DESCRIPTION
Currently, this fails the formatter if using weakdeps - packages extensions in Project.toml.

e.g. https://github.com/JuliaPlots/Plots.jl/actions/runs/4127586892/jobs/7130974959

cc @tkf.